### PR TITLE
Fixed problem with n_n_relation using same table for selection and primary table

### DIFF
--- a/application/models/grocery_crud_model.php
+++ b/application/models/grocery_crud_model.php
@@ -50,7 +50,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     	if($this->table_name === null)
     		return false;
     	
-    	$select = "`{$this->table_name}`.*";
+    	$select = "`this_table.*";
     	
     	//set_relation special queries 
     	if(!empty($this->relation))
@@ -72,7 +72,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     			}
     			
     			if($this->field_exists($related_field_title))
-    				$select .= ", `{$this->table_name}`.$related_field_title AS '{$this->table_name}.$related_field_title'";
+    				$select .= ", this_table.$related_field_title AS 'this_table.$related_field_title'";
     		}
     	}
     	
@@ -90,7 +90,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     	}
     	else 
     	{
-    		$results = $this->db->get($this->table_name)->result();
+    		$results = $this->db->get($this->table_name.' as this_table' )->result();
     	}
     	
     	return $results;
@@ -98,7 +98,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     
     public function set_primary_key($field_name, $table_name = null)
     {
-    	$table_name = $table_name === null ? $this->table_name : $table_name;
+    	$table_name = $table_name === null ? 'this_table' : $table_name;
     	
     	$this->primary_keys[$table_name] = $field_name;
     }
@@ -109,7 +109,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     	$temp_debug_value = $this->db->db_debug;
     	$this->db->db_debug = false;
     	
-    	$db_result = $this->db->get($this->table_name);
+    	$db_result = $this->db->get($this->table_name.' as this_table');
     	
     	//back to normal
     	$this->db->db_debug = $temp_debug_value;
@@ -152,9 +152,9 @@ class grocery_CRUD_Model  extends CI_Model  {
     		$primary_key_selection_table = $this->get_primary_key($selection_table);
     			 
     		//Sorry Codeigniter but you cannot help me with the subquery!
-    		$select .= ", (SELECT GROUP_CONCAT(DISTINCT $selection_table.$title_field_selection_table) FROM $selection_table "
-    			."LEFT JOIN $relation_table ON $relation_table.$primary_key_alias_to_selection_table = $selection_table.$primary_key_selection_table "
-    			."WHERE $relation_table.$primary_key_alias_to_this_table = `{$this->table_name}`.$this_table_primary_key GROUP BY $relation_table.$primary_key_alias_to_this_table) AS $field_name";
+    		$select .= ", ( SELECT GROUP_CONCAT(DISTINCT $selection_table.$title_field_selection_table) FROM $selection_table "
+                ."LEFT JOIN $relation_table ON $relation_table.$primary_key_alias_to_selection_table = $selection_table.$primary_key_selection_table "
+                ."WHERE $relation_table.$primary_key_alias_to_this_table = this_table.$this_table_primary_key GROUP BY $relation_table.$primary_key_alias_to_this_table) AS $field_name";
     	}
 
     	return $select;
@@ -205,7 +205,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     	//set_relation_n_n special queries. We prefer sub queries from a simple join for the relation_n_n as it is faster and more stable on big tables.
     	if(!empty($this->relation_n_n))
     	{
-    		$select = "{$this->table_name}.*";
+    		$select = "this_table.*";
     		$select = $this->relation_n_n_queries($select);
     		
     		$this->db->select($select,false);
@@ -216,7 +216,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     		}
     		else
     		{
-    			return $this->db->get($this->table_name)->num_rows();
+    			return $this->db->get($this->table_name.' as this_table')->num_rows();
     		}    		
     	}
     	else 
@@ -227,7 +227,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     		}
     		else
     		{
-    			return $this->db->get($this->table_name)->num_rows();
+    			return $this->db->get($this->table_name.' as this_table')->num_rows();
     		}
     	}
     }
@@ -246,7 +246,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     {
     	$primary_key_field = $this->get_primary_key();
     	$this->db->where($primary_key_field,$primary_key_value);
-    	$result = $this->db->get($this->table_name)->row();
+    	$result = $this->db->get($this->table_name.' as this_table')->row();
     	return $result;
     }
     
@@ -257,7 +257,7 @@ class grocery_CRUD_Model  extends CI_Model  {
 		if($related_primary_key !== false)
 		{
 			$unique_name = $this->_unique_join_name($field_name);
-			$this->db->join( $related_table.' as '.$unique_name , "$unique_name.$related_primary_key = {$this->table_name}.$field_name",'left');
+			$this->db->join( $related_table.' as '.$unique_name , "$unique_name.$related_primary_key = this_table.$field_name",'left');
 
 			$this->relation[$field_name] = array($field_name , $related_table , $related_field_title);
 			


### PR DESCRIPTION
The problem comes when you try to build a many to many relationship between a field in one table and another field in the same table.

For example, a table called pages has a primary key called id and another field called parent.  The parent field references the id field of the pages table.

The fix was adding an alias to mentions of this->table_name used in the "from" portion of most select queries in grocery_crud_model.php

This has been tested and works correctly under normal use.  Possible break points invovle queries which alter the table name (not set_table) or set_basic_table or get_field_types_basic_table  -- however, these functions are assumed to work.
