### PR TITLE
add where clause add last parameter in set_relation_n_n

### DIFF
--- a/application/libraries/grocery_crud.php
+++ b/application/libraries/grocery_crud.php
@@ -4180,8 +4180,9 @@ class grocery_CRUD extends grocery_CRUD_States
 	 * @param string $primary_key_alias_to_selection_table
 	 * @param string $title_field_selection_table
 	 * @param string $priority_field_relation_table
+	 * @param mixed $where_clause
 	 */
-	public function set_relation_n_n($field_name, $relation_table, $selection_table, $primary_key_alias_to_this_table, $primary_key_alias_to_selection_table , $title_field_selection_table , $priority_field_relation_table = null)
+	public function set_relation_n_n($field_name, $relation_table, $selection_table, $primary_key_alias_to_this_table, $primary_key_alias_to_selection_table , $title_field_selection_table , $priority_field_relation_table = null, $where_clause = null)
 	{
 		$this->relation_n_n[$field_name] = 
 			(object)array( 
@@ -4191,7 +4192,8 @@ class grocery_CRUD extends grocery_CRUD_States
 				'primary_key_alias_to_this_table' => $primary_key_alias_to_this_table, 
 				'primary_key_alias_to_selection_table' => $primary_key_alias_to_selection_table , 
 				'title_field_selection_table' => $title_field_selection_table , 
-				'priority_field_relation_table' => $priority_field_relation_table
+				'priority_field_relation_table' => $priority_field_relation_table,
+				'where_clause' => $where_clause
 			);
 			
 		return $this;

--- a/application/models/grocery_crud_model.php
+++ b/application/models/grocery_crud_model.php
@@ -401,10 +401,13 @@ class grocery_CRUD_Model  extends CI_Model  {
     
     function get_relation_n_n_unselected_array($field_info, $selected_values)
     {
+    	$use_where_clause = !empty($field_info->where_clause);
+    	
     	$select = "";
     	$related_field_title = $field_info->title_field_selection_table;
     	$use_template = strpos($related_field_title,'{') !== false;
     	$field_name_hash = $this->_unique_field_name($related_field_title);
+    	
     	if($use_template)
     	{
     		$related_field_title = str_replace(" ", "&nbsp;", $related_field_title);
@@ -415,6 +418,10 @@ class grocery_CRUD_Model  extends CI_Model  {
     		$select .= "$related_field_title as $field_name_hash";
     	}
     	$this->db->select('*, '.$select,false);
+    	
+    	if($use_where_clause){
+    		$this->db->where($field_info->where_clause);	
+    	}
     	
     	$selection_primary_key = $this->get_primary_key($field_info->selection_table);
         if(!$use_template)


### PR DESCRIPTION
Hi @scoumbourdis,
I've just make little addition. I add where clause as the last parameter of set_relation_n_n

Here is the code to include only sch_teacher with active = 1:

``` php
    $crud->set_relation_n_n('teachers', 
                'sch_schoolyear_subject_teacher', 'sch_teacher', 
                'schoolyear_subject_id', 'teacher_id',  '{code} - {name}', 
                        null, array('active'=>1));
```

The drawbacks is we will have to many parameters here (7 parameters just for a function, even if they are null by defaut).

What do you think?
