### PR TITLE
set_database function

### DIFF
--- a/application/libraries/grocery_crud.php
+++ b/application/libraries/grocery_crud.php
@@ -2862,7 +2862,7 @@ class grocery_CRUD extends grocery_CRUD_States
 	private $columns_checked		= false;
 	private $add_fields_checked		= false;
 	private $edit_fields_checked	= false;
-	private $set_datbase 		= false;
+	private $set_database 		= false;
 	
 	protected $default_theme		= 'flexigrid';
 	protected $language				= null;


### PR DESCRIPTION
I just had the problem that i have two database connections in one controller. I switched the database connection but grocerycrud dont do it aswell. Thats why i added this function.

Works as follows:
$crud->set_database($db_group_before[, $db_group_after]);

db_group_before = Set database group from config/databases.php
db_group_after = Optional (Group: default) otherwise sets the database connection to something after crud actions
