### PR TITLE
Update application/libraries/grocery_crud.php

### DIFF
--- a/application/libraries/grocery_crud.php
+++ b/application/libraries/grocery_crud.php
@@ -1434,8 +1434,10 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
 		
 		foreach($data->list as $num_row => $row)
 		{
-			$data->list[$num_row]->edit_url = $data->edit_url.'/'.$row->{$data->primary_key};
-			$data->list[$num_row]->delete_url = $data->delete_url.'/'.$row->{$data->primary_key};
+			if(isset($row->{$data->primary_key})){
+				$data->list[$num_row]->edit_url = $data->edit_url.'/'.$row->{$data->primary_key};
+				$data->list[$num_row]->delete_url = $data->delete_url.'/'.$row->{$data->primary_key};
+			}
 		}
 		
 		if(!$ajax)


### PR DESCRIPTION
When the id p.k in the DB is jumping numbers the $row->($data->primary_key) is not set and this cause a fatal error.
grocery_crud.php 1437
