### PR TITLE
relation n_n missing when unset field. Pull request 113

### DIFF
--- a/application/libraries/grocery_crud.php
+++ b/application/libraries/grocery_crud.php
@@ -926,8 +926,10 @@ class grocery_CRUD_Model_Driver extends grocery_CRUD_Field_Types
 				{
 					foreach($this->relation_n_n as $field_name => $field_info)
 					{
-						$relation_data = isset( $post_data[$field_name] ) ? $post_data[$field_name] : array() ; 
-						$this->db_relation_n_n_update($field_info, $relation_data ,$primary_key);
+						if (isset( $post_data[$field_name] ) ){
+							$relation_data = $post_data[$field_name]; 
+							$this->db_relation_n_n_update($field_info, $relation_data ,$primary_key);	
+						}	
 					}
 				}				
 				


### PR DESCRIPTION
If relation_n_n has no post field, it is deleted.
Just , if there is no post field do nothing. (Keep the relation in the same state)
