### PR TITLE
Translation Updates for German Language

### DIFF
--- a/assets/grocery_crud/languages/german.php
+++ b/assets/grocery_crud/languages/german.php
@@ -1,32 +1,31 @@
 <?php
-/*  Translated by: @Jan from Hamburg */
 	$lang['list_add'] 				= 'Neu:';
 	$lang['list_actions'] 			= 'Aktionen';
 	$lang['list_page'] 				= 'Seite';
 	$lang['list_paging_of'] 		= 'von';
-	$lang['list_displaying']		= 'Zeige {start} bis {end} von {results} Eintr&auml;gen';
-	$lang['list_filtered_from']		= '(gefiltert aus {total_results} Eintr&auml;gen insgesamt)';
-	$lang['list_show_entries']		= 'Zeige {paging} Eintr&auml;ge';
-	$lang['list_no_items']			= 'keine Eintr&auml;ge vorhanden';
-	$lang['list_zero_entries']		= 'Zeige 0 bis 0 von 0 Eintr&auml;gen';
+	$lang['list_displaying']		= 'Zeige {start} bis {end} von {results} Einträgen';
+	$lang['list_filtered_from']		= '(gefiltert aus {total_results} Einträgen insgesamt)';
+	$lang['list_show_entries']		= 'Zeige {paging} Einträge';
+	$lang['list_no_items']			= 'keine Einträge vorhanden';
+	$lang['list_zero_entries']		= 'Zeige 0 bis 0 von 0 Einträgen';
 	$lang['list_search'] 			= 'Suche';
 	$lang['list_search_all'] 		= 'Zeige alle';
 	$lang['list_clear_filtering'] 	= 'ohne Filter';
-	$lang['list_delete'] 			= 'L&ouml;schen';
-	$lang['list_edit'] 				= '&Auml;ndern';
+	$lang['list_delete'] 			= 'Löschen';
+	$lang['list_edit'] 				= 'Ändern';
 	$lang['list_paging_first'] 		= 'Erster';
 	$lang['list_paging_previous'] 	= 'Vorheriger';
-	$lang['list_paging_next'] 		= 'N&auml;chster';
+	$lang['list_paging_next'] 		= 'Nächster';
 	$lang['list_paging_last'] 		= 'Letzter';
 	$lang['list_loading'] 			= 'Lade...';
 
-	$lang['form_edit'] 				= '&Auml;ndern';
-	$lang['form_back_to_list'] 		= 'Zur&uuml;ck zur Liste';
-	$lang['form_update_changes'] 	= '&Auml;nderungen speichern';
+	$lang['form_edit'] 				= 'Ändern';
+	$lang['form_back_to_list'] 		= 'Zurück zur Liste';
+	$lang['form_update_changes'] 	= 'Änderungen speichern';
 	$lang['form_cancel'] 			= 'Abbrechen';
-	$lang['form_update_loading'] 	= 'Lade, speichere &Auml;nderungen...';
+	$lang['form_update_loading'] 	= 'Lade, speichere Änderungen...';
 	$lang['update_success_message'] = 'Daten erfolgreich aktualisiert.';
-	$lang['form_go_back_to_list'] 	= 'Gehe zur&uuml;ck zur Liste';
+	$lang['form_go_back_to_list'] 	= 'Gehe zurück zur Liste';
 
 	$lang['form_add'] 				= 'Neu:';
 	$lang['insert_success_message'] = 'Erfolgreich in die Datenbank eingetragen!';
@@ -35,25 +34,25 @@
 	$lang['form_insert_loading'] 	= 'Lade, speicher Daten...';
 
 	$lang['form_upload_a_file'] 	= 'Datei hochladen';
-	$lang['form_upload_delete'] 	= 'l&ouml;schen';
+	$lang['form_upload_delete'] 	= 'löschen';
 	$lang['form_button_clear'] 		= 'Leeren';
 
-	$lang['delete_success_message'] = 'Datensatz erfolgreich aus der Datenbank geloescht';
-	$lang['delete_error_message'] 	= 'Datensatz wurde nicht geloescht.';
+	$lang['delete_success_message'] = 'Datensatz erfolgreich aus der Datenbank gelöscht';
+	$lang['delete_error_message'] 	= 'Datensatz wurde nicht gelöscht.';
 
 	/* Javascript messages */
-	$lang['alert_add_form']			= 'Die Daten sind noch nicht gespeichert.\\nSicher, dass Du zurueck zur Liste willst?';
-	$lang['alert_edit_form']		= 'Die Korrektur ist noch nicht gespeichert.\\nSicher, dass Du zurueck zur Liste willst?';
-	$lang['alert_delete']			= 'Bist Du wirklich sicher, dass Du das loeschen willst und darfst?';
+	$lang['alert_add_form']			= 'Die Daten sind noch nicht gespeichert.\\nSicher, dass Sie zurück zur Liste wollen?';
+	$lang['alert_edit_form']		= 'Die Korrektur ist noch nicht gespeichert.\\nSicher, dass Sie zurück zur Liste wollen?';
+	$lang['alert_delete']			= 'Sind Sie wirklich sicher, dass Sie das löschen wollen und dürfen?';
 
-	$lang['insert_error']			= 'Bei dem Eintrag ist ein Fehler unterlaufen. Bitte pruefen.';
-	$lang['update_error']			= 'Ein Fehler beim Speichern. Bitte pruefen.';
+	$lang['insert_error']			= 'Bei dem Eintrag ist ein Fehler unterlaufen. Bitte prüfen.';
+	$lang['update_error']			= 'Ein Fehler beim Speichern. Bitte prüfen.';
 
 	/* Added in version 1.2.1 */
-	$lang['set_relation_title']		= 'Select {field_display_as}';
-	$lang['list_record']			= 'Record';
-	$lang['form_inactive']			= 'inactive';
-	$lang['form_active']			= 'active';
+	$lang['set_relation_title']		= '{field_display_as} wählen';
+	$lang['list_record']			= 'Eintrag';
+	$lang['form_inactive']			= 'inaktiv';
+	$lang['form_active']			= 'aktiv';
 
 	/* Added in version 1.2.2 */
 	$lang['form_save_and_go_back'] = 'Speichern und zur Übersicht';
@@ -63,14 +62,14 @@
 	$lang['string_delete_file'] = "Datei löschen";
 	$lang['string_progress'] = "Fortschritt: ";
 	$lang['error_on_uploading'] = "Beim Hochladen ist ein Fehler aufgetreten.";
-	$lang['message_prompt_delete_file'] = "Bist Du sicher, dass du die Datei löschen willst?";
+	$lang['message_prompt_delete_file'] = "Sind Sie sicher, dass Sie die Datei löschen wollen?";
 
-	$lang['error_max_number_of_files'] = "Du kannst nur eine Datei zur Zeit hochladen.";
+	$lang['error_max_number_of_files'] = "Sie können nur eine Datei gleicheitig hochladen.";
 	$lang['error_accept_file_types'] = "Der Dateityp ist unzulässig";
 	$lang['error_max_file_size'] = "Die hochgeladene Datei Übersteigt die maximale Dateigröße.";
 	$lang['error_min_file_size'] = "Leere Dateien können nicht hochgeladen werden";
 
 	/* Added in version 1.3.1 */
 	$lang['list_export'] 	= "Export";
-	$lang['list_print'] 	= "Print";
-	$lang['minimize_maximize'] = 'Minimize/Maximize';
+	$lang['list_print'] 	= "Druck";
+	$lang['minimize_maximize'] = 'Minimieren/Maximieren';


### PR DESCRIPTION
- Changed informal pronouns to formal version where appropriate.
- Added Translation for new fields added in version 1.2.1.
- Changed HTML entities and digraphs to UTF-8 characters to increase consistency.
