### PR TITLE
Properly sanitize filenames for uploads

### DIFF
--- a/application/libraries/grocery_crud.php
+++ b/application/libraries/grocery_crud.php
@@ -5064,12 +5064,15 @@ class UploadHandler
     private function _transliterate_characters($file_name)
 	{
 		include($this->default_config_path.'/translit_chars.php');
-		if ( ! isset($translit_characters))
+		if ( isset($translit_characters))
 		{
-			return preg_replace("/([^a-zA-Z0-9\.\-\_]+?){1}/i", '-', $file_name);
+			$file_name = preg_replace(array_keys($translit_characters), array_values($translit_characters), $file_name);
 		}
-		$transformed_file_name = preg_replace(array_keys($translit_characters), array_values($translit_characters), $file_name);
-		return str_replace(" ", "-", $transformed_file_name);
+
+		$file_name = preg_replace("/([^a-zA-Z0-9\.\-\_]+?){1}/i", '-', $file_name);
+		$file_name = str_replace(" ", "-", $file_name);
+
+		return preg_replace('/\-+/', '-', trim($file_name, '-'));
 	}
 
     private function orient_image($file_path) {


### PR DESCRIPTION
If there are translit characters replace them first.
After that remove all characters that aren't allowed and remove duplicate dashes.

Fixes issues with filenames like: ,,,''"'I am*() a super 'superawesome file+with a super awesome-name“””’xxxx-.jpg
