### PR TITLE
#141 - Maxlength for decimal numbers

### DIFF
--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -2177,7 +2177,12 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
 
 		$extra_attributes = '';
 		if(!empty($field_info->db_max_length))
-			$extra_attributes .= "maxlength='{$field_info->db_max_length}'";
+			if($field_info->type=='decimal'){
+				$decimal_lentgh = explode(',',$field_info->db_max_length);
+				$extra_attributes .= "maxlength='".($decimal_lentgh[0]+1)."'";
+			}else{
+				$extra_attributes .= "maxlength='{$field_info->db_max_length}'";
+			}
 		$input = "<input id='field-{$field_info->name}' name='{$field_info->name}' type='text' value=\"$value\" $extra_attributes />";
 		return $input;
 	}


### PR DESCRIPTION
Fixed issue #141, so that decimal numbers have enough max-length in
input field, accounting for the decimal character.
