### PR TITLE
Dropdown input 0 value fix

### DIFF
--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -2328,7 +2328,7 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
 		$options = array('' => '') + $field_info->extras;
 		foreach($options as $option_value => $option_label)
 		{
-			$selected = !empty($value) && $value == $option_value ? "selected='selected'" : '';
+			$selected = ($value != "") && $value == $option_value ? "selected='selected'" : '';
 			$input .= "<option value='$option_value' $selected >$option_label</option>";
 		}
 


### PR DESCRIPTION
PHP empty() function sees 0 as empty for example

Dropdown
0 => No
1 => Yes

if value comes 0, !empty($value) will be false and it won't be selected
