### PR TITLE
adding new feature columns_align to set alignment for displayed columns

### DIFF
--- a/application/controllers/examples.php
+++ b/application/controllers/examples.php
@@ -84,7 +84,7 @@ class Examples extends CI_Controller {
 
 			$this->_example_output($output);
 	}
-
+	
 	public function orders_management()
 	{
 			$crud = new grocery_CRUD();
@@ -245,5 +245,78 @@ class Examples extends CI_Controller {
 			return $output;
 		}
 	}
+	
+	public function column_align_right()
+	{
+			$crud = new grocery_CRUD();
 
+			$crud->set_table('customers');
+			$crud->columns('customerName','contactLastName','phone','city','country','salesRepEmployeeNumber','creditLimit');
+			$crud->columns_align(array('customerName' => 'right','contactLastName' => 'right','phone' => 'right','city' => 'right','country' => 'right','salesRepEmployeeNumber' => 'right','creditLimit' => 'right'));
+			$crud->display_as('salesRepEmployeeNumber','from Employeer')
+				 ->display_as('customerName','Name')
+				 ->display_as('contactLastName','Last Name');
+			$crud->set_subject('Customer');
+			$crud->set_relation('salesRepEmployeeNumber','employees','lastName');
+
+			$output = $crud->render();
+
+			$this->_example_output($output);
+	}
+	
+	public function column_align_center()
+	{
+			$crud = new grocery_CRUD();
+
+			$crud->set_table('customers');
+			$crud->columns('customerName','contactLastName','phone','city','country','salesRepEmployeeNumber','creditLimit');
+			$crud->columns_align(array('customerName' => 'center','contactLastName' => 'center','phone' => 'center','city' => 'center','country' => 'center','salesRepEmployeeNumber' => 'center','creditLimit' => 'center'));
+			$crud->display_as('salesRepEmployeeNumber','from Employeer')
+				 ->display_as('customerName','Name')
+				 ->display_as('contactLastName','Last Name');
+			$crud->set_subject('Customer');
+			$crud->set_relation('salesRepEmployeeNumber','employees','lastName');
+
+			$output = $crud->render();
+
+			$this->_example_output($output);
+	}
+
+	public function column_align_right2()
+	{
+			$crud = new grocery_CRUD();
+
+			$crud->set_table('customers');
+			$crud->set_theme('datatables');
+			$crud->columns('customerName','contactLastName','phone','city','country','salesRepEmployeeNumber','creditLimit');
+			$crud->columns_align(array('customerName' => 'right','contactLastName' => 'right','phone' => 'right','city' => 'right','country' => 'right','salesRepEmployeeNumber' => 'right','creditLimit' => 'right'));
+			$crud->display_as('salesRepEmployeeNumber','from Employeer')
+				 ->display_as('customerName','Name')
+				 ->display_as('contactLastName','Last Name');
+			$crud->set_subject('Customer');
+			$crud->set_relation('salesRepEmployeeNumber','employees','lastName');
+
+			$output = $crud->render();
+
+			$this->_example_output($output);
+	}
+	
+	public function column_align_center2()
+	{
+			$crud = new grocery_CRUD();
+
+			$crud->set_table('customers');
+			$crud->set_theme('datatables');
+			$crud->columns('customerName','contactLastName','phone','city','country','salesRepEmployeeNumber','creditLimit');
+			$crud->columns_align(array('customerName' => 'center','contactLastName' => 'center','phone' => 'center','city' => 'center','country' => 'center','salesRepEmployeeNumber' => 'center','creditLimit' => 'center'));
+			$crud->display_as('salesRepEmployeeNumber','from Employeer')
+				 ->display_as('customerName','Name')
+				 ->display_as('contactLastName','Last Name');
+			$crud->set_subject('Customer');
+			$crud->set_relation('salesRepEmployeeNumber','employees','lastName');
+
+			$output = $crud->render();
+
+			$this->_example_output($output);
+	}
 }

--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -3360,7 +3360,11 @@ class Grocery_CRUD extends grocery_CRUD_States
 	protected $state_code 			= null;
 	protected $state_info 			= null;
 	protected $columns				= null;
-
+	
+	// for column align's feature purpose
+	protected $columns_aligned 		= false;
+	protected $columns_align 		= null;
+	
 	private $basic_db_table_checked = false;
 	private $columns_checked		= false;
 	private $add_fields_checked		= false;
@@ -3483,6 +3487,27 @@ class Grocery_CRUD extends grocery_CRUD_States
 		return $this;
 	}
 
+	/** ------------------------------------------
+	 * User can change the displayed columns align
+	 * -------------------------------------------
+	 * @access	public	 
+	 * @param	array
+	 * @return	void
+	 */
+	public function columns_align($columns_align = array())
+	{		
+		if( ! empty($columns_align) && is_array($columns_align))
+		{
+			foreach($columns_align as $col => $align)
+			{				
+				$this->columns_align[$col] = $align;
+			}
+
+			$this->columns_aligned = TRUE;
+		}
+		
+		return $this;
+	}
 
 	/**
 	 * Set Validation Rules
@@ -4034,6 +4059,12 @@ class Grocery_CRUD extends grocery_CRUD_States
 					$new_column = $this->_unique_field_name($this->relation[$column][0]);
 					$this->columns[$col_num] = $new_column;
 
+					if ($this->columns_aligned && is_array($this->columns_align) && array_key_exists($column, $this->columns_align))
+					{
+						$align = $this->columns_align[$column];
+						$this->columns_align[$new_column] = $align;
+					}
+					
 					if(isset($this->display_as[$column]))
 					{
 						$display_as = $this->display_as[$column];
@@ -4058,6 +4089,13 @@ class Grocery_CRUD extends grocery_CRUD_States
 							if( $relation[2] == $column )
 							{
 								$new_column = $table_name.'.'.$column;
+								
+								if ($this->columns_aligned && is_array($this->columns_align) && array_key_exists($column, $this->columns_align))
+								{
+									$align = $this->columns_align[$column];
+									$this->columns_align[$new_column] = $align;
+								}
+								
 								if(isset($this->display_as[$column]))
 								{
 									$display_as = $this->display_as[$column];
@@ -4078,12 +4116,14 @@ class Grocery_CRUD extends grocery_CRUD_States
 				}
 
 				if(isset($this->display_as[$column]))
-					$this->columns[$col_num] = (object)array('field_name' => $column, 'display_as' => $this->display_as[$column]);
+					$this->columns[$col_num] = (object)array('field_name' => $column, 'display_as' => $this->display_as[$column],
+						'align' => isset($this->columns_align[$column]) ? $this->columns_align[$column] : '');
 				elseif(isset($field_types[$column]))
-					$this->columns[$col_num] = (object)array('field_name' => $column, 'display_as' => $field_types[$column]->display_as);
+					$this->columns[$col_num] = (object)array('field_name' => $column, 'display_as' => $field_types[$column]->display_as,
+						'align' => isset($this->columns_align[$column]) ? $this->columns_align[$column] : '');
 				else
 					$this->columns[$col_num] = (object)array('field_name' => $column, 'display_as' =>
-						ucfirst(str_replace('_',' ',$column)));
+						ucfirst(str_replace('_',' ',$column)), 'align' => isset($this->columns_align[$column]) ? $this->columns_align[$column] : '');
 
 				if(!empty($this->unset_columns) && in_array($column,$this->unset_columns))
 				{

--- a/application/views/example.php
+++ b/application/views/example.php
@@ -35,8 +35,13 @@ a:hover
 		<a href='<?php echo site_url('examples/employees_management')?>'>Employees</a> |		 
 		<a href='<?php echo site_url('examples/film_management')?>'>Films</a> | 
 		<a href='<?php echo site_url('examples/film_management_twitter_bootstrap')?>'>Twitter Bootstrap Theme [BETA]</a> | 
-		<a href='<?php echo site_url('examples/multigrids')?>'>Multigrid [BETA]</a>
-		
+		<a href='<?php echo site_url('examples/multigrids')?>'>Multigrid [BETA]</a>	
+	</div>
+	<div>
+		<a href='<?php echo site_url('examples/column_align_right')?>'>Flexigrid - Column Align Right</a> |
+		<a href='<?php echo site_url('examples/column_align_center')?>'>Flexigrid - Column Align Center</a> |
+		<a href='<?php echo site_url('examples/column_align_right2')?>'>Datatables - Column Align Right</a> |
+		<a href='<?php echo site_url('examples/column_align_center2')?>'>Datatables - Column Align Center</a> |
 	</div>
 	<div style='height:20px;'></div>  
     <div>

--- a/assets/grocery_crud/themes/datatables/views/list.php
+++ b/assets/grocery_crud/themes/datatables/views/list.php
@@ -2,7 +2,8 @@
 	<thead>
 		<tr>
 			<?php foreach($columns as $column){?>
-				<th><?php echo $column->display_as; ?></th>
+				<?php $text_align = (empty($column->align) ? '' : ('style="text-align:'.$column->align.'"')); ?>
+				<th <?php echo $text_align;?>><?php echo $column->display_as; ?></th>
 			<?php }?>
 			<?php if(!$unset_delete || !$unset_edit || !$unset_read || !empty($actions)){?>
 			<th class='actions'><?php echo $this->l('list_actions'); ?></th>
@@ -13,7 +14,8 @@
 		<?php foreach($list as $num_row => $row){ ?>
 		<tr id='row-<?php echo $num_row?>'>
 			<?php foreach($columns as $column){?>
-				<td><?php echo $row->{$column->field_name}?></td>
+				<?php $text_align = (empty($column->align) ? '' : ('align="'.$column->align.'"')); ?>
+				<td <?php echo $text_align;?>><?php echo $row->{$column->field_name}?></td>
 			<?php }?>
 			<?php if(!$unset_delete || !$unset_edit || !$unset_read || !empty($actions)){?>
 			<td class='actions'>

--- a/assets/grocery_crud/themes/flexigrid/views/list.php
+++ b/assets/grocery_crud/themes/flexigrid/views/list.php
@@ -9,7 +9,8 @@
 			<tr class='hDiv'>
 				<?php foreach($columns as $column){?>
 				<th width='<?php echo $column_width?>%'>
-					<div class="text-left field-sorting <?php if(isset($order_by[0]) &&  $column->field_name == $order_by[0]){?><?php echo $order_by[1]?><?php }?>" 
+					<?php $text_align = "text-".(empty($column->align) ? 'left' : $column->align); ?>
+					<div class="<?php echo $text_align;?> field-sorting <?php if(isset($order_by[0]) &&  $column->field_name == $order_by[0]){?><?php echo $order_by[1]?><?php }?>" 
 						rel='<?php echo $column->field_name?>'>
 						<?php echo $column->display_as?>
 					</div>
@@ -29,7 +30,8 @@
 		<tr  <?php if($num_row % 2 == 1){?>class="erow"<?php }?>>
 			<?php foreach($columns as $column){?>
 			<td width='<?php echo $column_width?>%' class='<?php if(isset($order_by[0]) &&  $column->field_name == $order_by[0]){?>sorted<?php }?>'>
-				<div class='text-left'><?php echo $row->{$column->field_name} != '' ? $row->{$column->field_name} : '&nbsp;' ; ?></div>
+				<?php $text_align = "text-".(empty($column->align) ? 'left' : $column->align); ?>
+				<div class="<?php echo $text_align;?>"><?php echo $row->{$column->field_name} != '' ? $row->{$column->field_name} : '&nbsp;' ; ?></div>
 			</td>
 			<?php }?>
 			<?php if(!$unset_delete || !$unset_edit || !$unset_read || !empty($actions)){?>


### PR DESCRIPTION
# New Feature `columns_align()`
## Description : 

This function used to set alignment for displayed columns
## How to use:

`columns_align` take array as parameters. It should be `column_name` as a **key** and `alignment_type` as **value**.
## Examples:

```
$crud = new grocery_CRUD();
$crud->columns('column1', 'column2', 'column3');
$crud->columns_align(array('column1' => 'center', 'column3' => 'right'));
....
```

that will produce:

column1 in center alignment
column2 in left alignment (default)
column3 in right alignment

See this:
![flexigrid-column-align-right](https://f.cloud.github.com/assets/2386359/1580266/b5a9016a-51b8-11e3-80ca-29dc71aee9e8.png)
![flexigrid-column-align-center](https://f.cloud.github.com/assets/2386359/1580267/b77d011c-51b8-11e3-823f-21a90a38f9fa.png)
![datatables-column-align-right](https://f.cloud.github.com/assets/2386359/1580268/b975053c-51b8-11e3-878d-7ecad805789f.png)
![datatables-column-align-center](https://f.cloud.github.com/assets/2386359/1580269/bb792ade-51b8-11e3-9cb8-d8d1ec432db2.png)

I have add this example in examples file.
