### PR TITLE
add `get_real_fields()` function to check whether column is real or fake field.

### DIFF
--- a/application/controllers/examples.php
+++ b/application/controllers/examples.php
@@ -73,18 +73,31 @@ class Examples extends CI_Controller {
 			$crud = new grocery_CRUD();
 
 			$crud->set_table('customers');
-			$crud->columns('customerName','contactLastName','phone','city','country','salesRepEmployeeNumber','creditLimit');
+			$crud->columns('customerName','contactLastName','phone','city','country','salesRepEmployeeNumber','creditLimit','CreditCategory');
 			$crud->display_as('salesRepEmployeeNumber','from Employeer')
 				 ->display_as('customerName','Name')
 				 ->display_as('contactLastName','Last Name');
 			$crud->set_subject('Customer');
 			$crud->set_relation('salesRepEmployeeNumber','employees','lastName');
+			$crud->callback_column('CreditCategory',array($this,'getCreditCategory'));
 
 			$output = $crud->render();
 
 			$this->_example_output($output);
 	}
 
+	public function getCreditCategory($value, $row)
+	{
+		if ($row->creditLimit>100000)
+			return 'High';
+		
+		if ($row->creditLimit>=50000 && $row->creditLimit<=100000)
+			return 'Medium';
+		
+		if ($row->creditLimit<50000)
+			return 'Low';
+	}
+	
 	public function orders_management()
 	{
 			$crud = new grocery_CRUD();

--- a/assets/grocery_crud/themes/flexigrid/views/list_template.php
+++ b/assets/grocery_crud/themes/flexigrid/views/list_template.php
@@ -104,8 +104,11 @@ if($success_message !== null){?>
 			<select name="search_field" id="search_field">
 				<option value=""><?php echo $this->l('list_search_all');?></option>
 				<?php foreach($columns as $column){?>
-				<option value="<?php echo $column->field_name?>"><?php echo $column->display_as?>&nbsp;&nbsp;</option>
-				<?php }?>
+				<?php if (in_array($column->field_name, $real_fields))
+					{ ?>
+						<option value="<?php echo $column->field_name?>"><?php echo $column->display_as?>&nbsp;&nbsp;</option>
+					<?php }
+				}?>
 			</select>
             <input type="button" value="<?php echo $this->l('list_search');?>" class="crud_search" id='crud_search'>
 		</div>


### PR DESCRIPTION
add variable `$real_fields` and `get_real_fields()` function to check whether column is real or fake field.

For normal situation, with callback column, which is a fake field, it will be error **"unknwon column"**  when we try to search with this 'field'.  

I have modified `customers_management` function by adding CreditCategory as callback_column.  And when I search by this column (CreditCategory), it throws Error Number 1054.

![unknown column](https://f.cloud.github.com/assets/2386359/1670450/28a2e3fa-5c97-11e3-8640-ee83dccd5f50.PNG)

I have modified **list_template.php** in flexigrid views to filter that only real field will be available to be searched.

Hi @blakdronzer, does this solve your issue #229 ?
