### PR TITLE
callback_insert return primary key

### DIFF
--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -962,7 +962,11 @@ class grocery_CRUD_Model_Driver extends grocery_CRUD_Field_Types
 			{
 					$callback_return = call_user_func($this->callback_insert, $post_data);
 
-					if($callback_return === false)
+					if($callback_return !== false)
+					{
+						$insert_primary_key = $callback_return;
+					}
+					else
 					{
 						return false;
 					}


### PR DESCRIPTION
bug:
plain insert without callback, user can edit the data that have been inserted.
if we're using callback_insert, user can't edit the data that have been inserted. 

solution:
callback_insert now return the primary key or false, if return primary key, user can edit the data after submitted the insert form

below example the callback_insert function from http://www.grocerycrud.com/documentation/options_functions/callback_insert

function encrypt_password_and_insert_callback($post_array) {
  $this->load->library('encrypt');
  $key = 'super-secret-key';
  $post_array['password'] = $this->encrypt->encode($post_array['password'], $key);

  if ($this->db->insert('db_user',$post_array))
      return $this->db->insert_id();
  else
      return false;
}
