### PR TITLE
Update grocery_crud_model.php

### DIFF
--- a/application/models/grocery_crud_model.php
+++ b/application/models/grocery_crud_model.php
@@ -327,7 +327,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     	{
     		$this->db->order_by("{$field_info->relation_table}.{$field_info->priority_field_relation_table}");
     	}
-    	$this->db->where($field_info->primary_key_alias_to_this_table, $primary_key_value);
+    	$this->db->where("{$field_info->relation_table}.{$field_info->primary_key_alias_to_this_table}", $primary_key_value);
     	$this->db->join(
     			$field_info->selection_table,
     			"{$field_info->relation_table}.{$field_info->primary_key_alias_to_selection_table} = {$field_info->selection_table}.{$selection_primary_key}"


### PR DESCRIPTION
fix error "ambiguous column" that occurs in a reflexive relationship n_n when the where clause has a field that is in the two tables
