### PR TITLE
Document unset_add/edit/read_fields functions

### DIFF
--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -3799,6 +3799,10 @@ class Grocery_CRUD extends grocery_CRUD_States
 		return $this;
 	}
 
+	/**
+	 * Unsets fields from the add form
+	 * Fields set using this function will be used in place of fields set using unset_fields
+	 */
 	public function unset_add_fields()
 	{
 		$args = func_get_args();
@@ -3813,6 +3817,10 @@ class Grocery_CRUD extends grocery_CRUD_States
 		return $this;
 	}
 
+	/**
+	 * Unsets fields from the edit form
+	 * Fields set using this function will be used in place of fields set using unset_fields
+	 */
 	public function unset_edit_fields()
 	{
 		$args = func_get_args();
@@ -3827,6 +3835,10 @@ class Grocery_CRUD extends grocery_CRUD_States
 		return $this;
 	}
 
+	/**
+	 * Unsets fields from the read page
+	 * Fields set using this function will be used in place of fields set using unset_fields
+	 */
 	public function unset_read_fields()
 	{
 		$args = func_get_args();


### PR DESCRIPTION
It wasn't immediately obvious to me that these functions would replace the fields set using `unset_fields`. This will make it more clear.
