### PR TITLE
Twitter Bootstrap Add/Edit: One primary button, style cancel button as btn-warning

### DIFF
--- a/assets/grocery_crud/themes/twitter-bootstrap/views/add.php
+++ b/assets/grocery_crud/themes/twitter-bootstrap/views/add.php
@@ -68,10 +68,10 @@ $this->set_js($this->default_theme_path.'/twitter-bootstrap/js/jquery.functions.
 			}
 			?>
 
-			<input type="button" value="<?php echo $this->l('form_save'); ?>"  class="btn btn-large btn-primary submit-form"/>
+			<input type="button" value="<?php echo $this->l('form_save'); ?>"  class="btn btn-large <?php if($this->unset_back_to_list){ ?>btn-primary<?php } ?> submit-form"/>
 			<?php 	if(!$this->unset_back_to_list) { ?>
 				<input type="button" value="<?php echo $this->l('form_save_and_go_back'); ?>" id="save-and-go-back-button"  class="btn btn-large btn-primary"/>
-				<input type="button" value="<?php echo $this->l('form_cancel'); ?>" class="btn btn-large return-to-list" />
+				<input type="button" value="<?php echo $this->l('form_cancel'); ?>" class="btn btn-large btn-warning return-to-list" />
 			<?php 	} ?>
 
 			<div class="hide loading" id="ajax-loading"><?php echo $this->l('form_update_loading'); ?></div>

--- a/assets/grocery_crud/themes/twitter-bootstrap/views/edit.php
+++ b/assets/grocery_crud/themes/twitter-bootstrap/views/edit.php
@@ -72,10 +72,10 @@ $this->set_js($this->default_theme_path.'/twitter-bootstrap/js/jquery.functions.
 					echo $hidden_field->input;
 				}
 			}?>
-			<input type="button" value="<?php echo $this->l('form_update_changes'); ?>" class="btn btn-large btn-primary submit-form"/>
+			<input type="button" value="<?php echo $this->l('form_update_changes'); ?>" class="btn btn-large <?php if($this->unset_back_to_list){ ?>btn-primary<?php } ?> submit-form"/>
 			<?php 	if(!$this->unset_back_to_list) { ?>
 				<input type="button" value="<?php echo $this->l('form_update_and_go_back'); ?>" id="save-and-go-back-button" class="btn btn-large btn-primary"/>
-				<input type="button" value="<?php echo $this->l('form_cancel'); ?>" class="btn btn-large return-to-list" />
+				<input type="button" value="<?php echo $this->l('form_cancel'); ?>" class="btn btn-large btn-warning return-to-list" />
 			<?php 	} ?>
 
 			<div class="hide loading" id="ajax-loading"><?php echo $this->l('form_update_loading'); ?></div>


### PR DESCRIPTION
There should only be one primary button, or none at all. I chose to make the "save and go back to list" button the primary button if it's present and the  "save" button otherwise.

I also have given the "cancel" button the class `btn-warning`. See [here](http://getbootstrap.com/2.3.2/base-css.html#buttons) for the looks of this button.
