### PR TITLE
Avoiding SQL field name conflicts

### DIFF
--- a/application/models/grocery_crud_model.php
+++ b/application/models/grocery_crud_model.php
@@ -311,7 +311,7 @@ class grocery_CRUD_Model  extends CI_Model  {
     	}
     	else
     	{
-    		$select .= "$related_field_title as $field_name_hash";
+    		$select .= "{$field_info->selection_table}.{$field_info->title_field_selection_table} as $field_name_hash";
     	}
     	$this->db->select('*, '.$select,false);
 


### PR DESCRIPTION
Corrects a problem when the field name is ambiguous in the SQL.  By adding the table name prefix, no field conflicts can occur during a relational query. Fixes "Avoid field name conflicts appending table name #234"
