### PR TITLE
bug fix

### DIFF
--- a/application/models/grocery_crud_model.php
+++ b/application/models/grocery_crud_model.php
@@ -432,10 +432,12 @@ class grocery_CRUD_Model  extends CI_Model  {
     	{
     		$type = explode("(",$db_field_type->Type);
     		$db_type = $type[0];
-
     		if(isset($type[1]))
     		{
-    			if(substr($type[1],-1) == ')')
+    		    if($db_type == "set"){
+    		        $length = substr($db_field_type->Type,4,-1);
+    		    }
+    			else if(substr($type[1],-1) == ')')
     			{
     				$length = substr($type[1],0,-1);
     			}

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,5 @@
+v 1.5.1
+	#290 - Added functionality to define upload file types per field (pull request from syrys)
 v 1.5.0
 	#211 - Bug if use where clause.
 	#197 - Properly sanitize filenames for uploads.


### PR DESCRIPTION
If db object property is set, and the property field has included the symbol single quote '. 
Causes the string length error, impact the display string not completely.