### PR TITLE
List View Button change label to german "Anzeigen"

### DIFF
--- a/assets/grocery_crud/languages/german.php
+++ b/assets/grocery_crud/languages/german.php
@@ -76,7 +76,7 @@
 
 
 	/* Added in version 1.4 */
-	$lang['list_view'] = 'View';
+	$lang['list_view'] = 'Anzeigen';
 
 	/* Added in version 1.5.1 */
 	$lang['ui_day'] = 'dd';


### PR DESCRIPTION
In german list view the "View" button next to edit and delete was still called "View" in german language.

Only change in line 79 $lang['list_view'] = 'Anzeigen';