### PR TITLE
added 'order by' option to set_relation_n_n

### DIFF
--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -5129,7 +5129,7 @@ class Grocery_CRUD extends grocery_CRUD_States
 	 * @param mixed $where_clause
      * @return Grocery_CRUD
 	 */
-	public function set_relation_n_n($field_name, $relation_table, $selection_table, $primary_key_alias_to_this_table, $primary_key_alias_to_selection_table , $title_field_selection_table , $priority_field_relation_table = null, $where_clause = null)
+	public function set_relation_n_n($field_name, $relation_table, $selection_table, $primary_key_alias_to_this_table, $primary_key_alias_to_selection_table , $title_field_selection_table , $priority_field_relation_table = null, $where_clause = null, $order_by = null)
 	{
 		$this->relation_n_n[$field_name] =
 			(object)array(
@@ -5140,7 +5140,8 @@ class Grocery_CRUD extends grocery_CRUD_States
 				'primary_key_alias_to_selection_table' => $primary_key_alias_to_selection_table ,
 				'title_field_selection_table' => $title_field_selection_table ,
 				'priority_field_relation_table' => $priority_field_relation_table,
-				'where_clause' => $where_clause
+				'where_clause' => $where_clause,
+				'order_by' => $order_by
 			);
 
 		return $this;

--- a/application/models/Grocery_crud_model.php
+++ b/application/models/Grocery_crud_model.php
@@ -300,6 +300,7 @@ class Grocery_crud_model  extends CI_Model  {
 
     function get_relation_n_n_selection_array($primary_key_value, $field_info)
     {
+		$use_order_by = !empty($field_info->order_by);
     	$select = "";
     	$related_field_title = $field_info->title_field_selection_table;
     	$use_template = strpos($related_field_title,'{') !== false;;
@@ -320,7 +321,10 @@ class Grocery_crud_model  extends CI_Model  {
     	if(empty($field_info->priority_field_relation_table))
     	{
     		if(!$use_template){
-    			$this->db->order_by("{$field_info->selection_table}.{$field_info->title_field_selection_table}");
+				if($use_order_by)
+    				$this->db->order_by("{$field_info->selection_table}.{$field_info->order_by}");
+    			else
+    				$this->db->order_by("{$field_info->selection_table}.{$field_info->title_field_selection_table}");
     		}
     	}
     	else
@@ -346,6 +350,7 @@ class Grocery_crud_model  extends CI_Model  {
     function get_relation_n_n_unselected_array($field_info, $selected_values)
     {
     	$use_where_clause = !empty($field_info->where_clause);
+		$use_order_by = !empty($field_info->order_by);
 
     	$select = "";
     	$related_field_title = $field_info->title_field_selection_table;
@@ -368,9 +373,13 @@ class Grocery_crud_model  extends CI_Model  {
     	}
 
     	$selection_primary_key = $this->get_primary_key($field_info->selection_table);
-        if(!$use_template)
-        	$this->db->order_by("{$field_info->selection_table}.{$field_info->title_field_selection_table}");
+		if(!$use_template){
+        	if($use_order_by)
+        		$this->db->order_by("{$field_info->selection_table}.{$field_info->order_by}");
+        	else
+        		$this->db->order_by("{$field_info->selection_table}.{$field_info->title_field_selection_table}");
         $results = $this->db->get($field_info->selection_table)->result();
+        }
 
         $results_array = array();
         foreach($results as $row)


### PR DESCRIPTION
I added an optional "order by" parameter to the set_relation_n_n function. This allows sorting of the items in the multiselect list based on another field in the selection table.