### PR TITLE
Grocery_CRUD library - added unset_search and unset_refresh options

### DIFF
--- a/application/controllers/Examples.php
+++ b/application/controllers/Examples.php
@@ -244,5 +244,76 @@ class Examples extends CI_Controller {
 			return $output;
 		}
 	}
+        
+	function unset_search_unset_refresh()
+	{
+		$this->config->load('grocery_crud');
+		$this->config->set_item('grocery_crud_dialog_forms',true);
+		$this->config->set_item('grocery_crud_default_per_page',10);
+
+		$output1 = $this->customers_flexigrid_unset_search_unset_refresh();
+
+		$output2 = $this->customers_datatables_unset_search_unset_refresh();
+
+
+		$js_files = $output1->js_files + $output2->js_files;
+		$css_files = $output1->css_files + $output2->css_files;
+		$output = "<h1>List 1</h1>".$output1->output."<h1>List 2</h1>".$output2->output;
+
+		$this->_example_output((object)array(
+				'js_files' => $js_files,
+				'css_files' => $css_files,
+				'output'	=> $output
+		));
+	}
+
+	public function customers_flexigrid_unset_search_unset_refresh()
+	{
+            $crud = new grocery_CRUD();
+
+            $crud->set_table('customers');
+            $crud->set_theme('flexigrid');
+            $crud->columns('customerName','contactLastName','phone','city','country','salesRepEmployeeNumber','creditLimit');
+            $crud->display_as('salesRepEmployeeNumber','from Employeer')
+                    ->display_as('customerName','Name')
+                    ->display_as('contactLastName','Last Name');
+            $crud->set_subject('Customer');
+            $crud->set_relation('salesRepEmployeeNumber','employees','lastName');
+            $crud->set_crud_url_path(site_url(strtolower(__CLASS__."/".__FUNCTION__)),site_url(strtolower(__CLASS__."/unset_search")));
+            $crud->unset_search();
+            $crud->unset_refresh();
+            $output = $crud->render();
+
+            if($crud->getState() != 'list') {
+                $this->_example_output($output);
+            } else {
+                return $output;
+            }
+	}
+
+	public function customers_datatables_unset_search_unset_refresh()
+	{
+            
+            $crud = new grocery_CRUD();
+
+            $crud->set_table('customers');
+            $crud->set_theme('datatables');
+            $crud->columns('customerName','contactLastName','phone','city','country','salesRepEmployeeNumber','creditLimit');
+            $crud->display_as('salesRepEmployeeNumber','from Employeer')
+                    ->display_as('customerName','Name')
+                    ->display_as('contactLastName','Last Name');
+            $crud->set_subject('Customer');
+            $crud->set_relation('salesRepEmployeeNumber','employees','lastName');
+            $crud->set_crud_url_path(site_url(strtolower(__CLASS__."/".__FUNCTION__)),site_url(strtolower(__CLASS__."/unset_search")));
+            $crud->unset_search();
+            $crud->unset_refresh();
+            $output = $crud->render();
+
+            if($crud->getState() != 'list') {
+                $this->_example_output($output);
+            } else {
+                return $output;
+            }
+	}
 
 }

--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -1596,6 +1596,8 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
 		$data->unset_delete			= $this->unset_delete;
 		$data->unset_export			= $this->unset_export;
 		$data->unset_print			= $this->unset_print;
+		$data->unset_search			= $this->unset_search;
+		$data->unset_refresh			= $this->unset_refresh;
 
 		$default_per_page = $this->config->default_per_page;
 		$data->paging_options = $this->config->paging_options;
@@ -3525,6 +3527,8 @@ class Grocery_CRUD extends grocery_CRUD_States
 	protected $unset_add_fields 	= null;
 	protected $unset_edit_fields	= null;
 	protected $unset_read_fields	= null;
+        protected $unset_search                 = false;
+        protected $unset_refresh                = false;
 
 	/* Callbacks */
 	protected $callback_before_insert 	= null;
@@ -3802,6 +3806,30 @@ class Grocery_CRUD extends grocery_CRUD_States
 		return $this;
 	}
 
+        /**
+         * Unsets the serach inputs from the list
+         * 
+         * @return \Grocery_CRUD
+         */
+        public function unset_search()
+        {
+                $this->unset_search = true;
+
+                return $this;
+        }
+
+        /**
+         * Unsets the refresh button from the list
+         * 
+         * @return \Grocery_CRUD
+         */
+        public function unset_refresh()
+        {
+                $this->unset_refresh = true;
+
+                return $this;
+        }
+        
 	/**
 	 * Unsets all the operations from the list
 	 *

--- a/application/views/example.php
+++ b/application/views/example.php
@@ -19,7 +19,8 @@ foreach($css_files as $file): ?>
 		<a href='<?php echo site_url('examples/offices_management')?>'>Offices</a> | 
 		<a href='<?php echo site_url('examples/employees_management')?>'>Employees</a> |		 
 		<a href='<?php echo site_url('examples/film_management')?>'>Films</a> |
-		<a href='<?php echo site_url('examples/multigrids')?>'>Multigrid [BETA]</a>
+		<a href='<?php echo site_url('examples/multigrids')?>'>Multigrid [BETA]</a> |
+		<a href='<?php echo site_url('examples/unset_search_unset_refresh')?>'>unset_search_unset_refresh [NEW]</a>
 		
 	</div>
 	<div style='height:20px;'></div>  

--- a/assets/grocery_crud/themes/datatables/js/datatables.js
+++ b/assets/grocery_crud/themes/datatables/js/datatables.js
@@ -178,7 +178,7 @@ function loadDataTable(this_datatables) {
 			});
 			add_edit_button_listener();
 		},
-		"sDom": 'T<"clear"><"H"lfr>t<"F"ip>',
+		"sDom": 'T<"clear"><"H"l' + (unset_search != true ? 'f' : '') +'r>t<"F"ip>',
 	    "oTableTools": {
 	    	"aButtons": aButtons,
 	        "sSwfPath": base_url+"assets/grocery_crud/themes/datatables/extras/TableTools/media/swf/copy_csv_xls_pdf.swf"

--- a/assets/grocery_crud/themes/datatables/views/list.php
+++ b/assets/grocery_crud/themes/datatables/views/list.php
@@ -53,22 +53,32 @@
 		</tr>
 		<?php }?>
 	</tbody>
+        <?php if (!$unset_search || !$unset_refresh) { ?>
 	<tfoot>
 		<tr>
-			<?php foreach($columns as $column){?>
-				<th><input type="text" name="<?php echo $column->field_name; ?>" placeholder="<?php echo $this->l('list_search').' '.$column->display_as; ?>" class="search_<?php echo $column->field_name; ?>" /></th>
-			<?php }?>
+                        <?php if(!$unset_search) { ?>
+                            <?php foreach($columns as $column){?>
+                                <th><input type="text" name="<?php echo $column->field_name; ?>" placeholder="<?php echo $this->l('list_search').' '.$column->display_as; ?>" class="search_<?php echo $column->field_name; ?>" /></th>
+                            <?php }?>
+			<?php } else { ?>
+                                <th colspan="<?php echo count($columns); ?>">&nbsp;</th>
+                        <?php }?>
 			<?php if(!$unset_delete || !$unset_edit || !$unset_read || !empty($actions)){?>
 				<th>
+                                        <?php if(!$unset_refresh) { ?>
 					<button class="ui-button ui-widget ui-state-default ui-corner-all ui-button-icon-only floatR refresh-data" role="button" data-url="<?php echo $ajax_list_url; ?>">
 						<span class="ui-button-icon-primary ui-icon ui-icon-refresh"></span><span class="ui-button-text">&nbsp;</span>
 					</button>
+                                        <?php }?>
+                                        <?php if(!$unset_search) { ?>
 					<a href="javascript:void(0)" role="button" class="clear-filtering ui-button ui-widget ui-state-default ui-corner-all ui-button-text-icon-primary floatR">
 						<span class="ui-button-icon-primary ui-icon ui-icon-arrowrefresh-1-e"></span>
 						<span class="ui-button-text"><?php echo $this->l('list_clear_filtering');?></span>
 					</a>
+                                        <?php }?>
 				</th>
 			<?php }?>
 		</tr>
 	</tfoot>
+        <?php }?>
 </table>

--- a/assets/grocery_crud/themes/datatables/views/list_template.php
+++ b/assets/grocery_crud/themes/datatables/views/list_template.php
@@ -59,6 +59,8 @@
 
 	var export_text = '<?php echo $this->l('list_export');?>';
 	var print_text = '<?php echo $this->l('list_print');?>';
+        
+        var unset_search = <?php echo ($unset_search ? 'true' : 'false'); ?>;
 
 	<?php
 	//A work around for method order_by that doesn't work correctly on datatables theme

--- a/assets/grocery_crud/themes/flexigrid/js/flexigrid.js
+++ b/assets/grocery_crud/themes/flexigrid/js/flexigrid.js
@@ -72,7 +72,7 @@ $(function(){
 			createCookie('per_page_'+unique_hash,$('#per_page').val(),1);
 			createCookie('hidden_ordering_'+unique_hash,$('#hidden-ordering').val(),1);
 			createCookie('hidden_sorting_'+unique_hash,$('#hidden-sorting').val(),1);
-			createCookie('search_text_'+unique_hash,$(this).closest('.flexigrid').find('.search_text').val(),1);
+			createCookie('search_text_'+unique_hash,$(this).closest('.flexigrid').find('.search_text').val() || "",1);
 			createCookie('search_field_'+unique_hash,$('#search_field').val(),1);
 		}
 

--- a/assets/grocery_crud/themes/flexigrid/views/list_template.php
+++ b/assets/grocery_crud/themes/flexigrid/views/list_template.php
@@ -101,6 +101,7 @@ if($success_message !== null){?>
 	</div>
 	<?php echo form_open( $ajax_list_url, 'method="post" id="filtering_form" class="filtering_form" autocomplete = "off" data-ajax-list-info-url="'.$ajax_list_info_url.'"'); ?>
 	<div class="sDiv quickSearchBox" id='quickSearchBox'>
+            <?php if(!$unset_search) { ?>
 		<div class="sDiv2">
 			<?php echo $this->l('list_search');?>: <input type="text" class="qsbsearch_fieldox search_text" name="search_text" size="30" id='search_text'>
 			<select name="search_field" id="search_field">
@@ -111,6 +112,7 @@ if($success_message !== null){?>
 			</select>
             <input type="button" value="<?php echo $this->l('list_search');?>" class="crud_search" id='crud_search'>
 		</div>
+            <?php }?>
         <div class='search-div-clear-button'>
         	<input type="button" value="<?php echo $this->l('list_clear_filtering');?>" id='search_clear' class="search_clear">
         </div>
@@ -160,6 +162,7 @@ if($success_message !== null){?>
 			</div>
 			<div class="btnseparator">
 			</div>
+                        <?php if(!$unset_refresh) { ?>
 			<div class="pGroup">
 				<div class="pReload pButton ajax_refresh_and_loading" id='ajax_refresh_and_loading'>
 					<span></span>
@@ -167,6 +170,7 @@ if($success_message !== null){?>
 			</div>
 			<div class="btnseparator">
 			</div>
+                        <?php }?>
 			<div class="pGroup">
 				<span class="pPageStat">
 					<?php $paging_starts_from = "<span id='page-starts-from' class='page-starts-from'>1</span>"; ?>


### PR DESCRIPTION
We are using Grocery Crud in a project and we needed to hide the search and the refresh functionality on some screens. We bought the bootstrap theme, and we also changed that theme. If You accept this pull request, i can send You the bootsrap theme changes too. We implemented also the unset_multiple_delete (for unset the multiple delete function) and the set_buttons_fit (visible buttons in the table row) methods.

Grocery_CRUD library
	added unset_search, unset_refresh attributes
	added unset_search, unset_refresh setter methods
example view
	added new navigation point for new demo
Examples controller
	added new methods for demo
assets/grocery_crud/themes/datatables
	added if statements for new attributes
assets/grocery_crud/themes/flexigrid
	added if statements for new attributes