### PR TITLE
adding escape to order_by

### DIFF
--- a/application/models/Grocery_crud_model.php
+++ b/application/models/Grocery_crud_model.php
@@ -135,9 +135,9 @@ class Grocery_crud_model  extends CI_Model  {
     	return $select;
     }
 
-    function order_by($order_by , $direction)
+    function order_by($order_by, $direction, $escape = NULL)
     {
-    	$this->db->order_by( $order_by , $direction );
+        $this->db->order_by($order_by, $direction, $escape);
     }
 
     function where($key, $value = NULL, $escape = TRUE)


### PR DESCRIPTION
adding ability of escape to be turned off by setting it false.
so when I set escape false, and use order_by("Column1 = SomeValue DESC") will not return any errors