### PR TITLE
Searching in grid with value 0 is not working

### DIFF
--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -3228,7 +3228,12 @@ class grocery_CRUD_States extends grocery_CRUD_Layout
                 {
                     $state_info->order_by = $data['order_by'];
                 }
-                if(!empty($data['search_text']))
+		/**
+		 * if search field value contains 0 then it does not work - empty("0") = true
+		 * fix will be to change condition: check empty string 
+		 * trim($data['search_text']) != "" || !empty($data['search_text')
+		 **/
+                if(trim($data['search_text']) != "" || !empty($data['search_text']))
                 {
                     if(empty($data['search_field']))
                     {


### PR DESCRIPTION
If we search using value 0 in the filter section, the search field is ignored as 
empty("0") will always return true