### PR TITLE
Updated chosen triggers with current naming

### DIFF
--- a/assets/grocery_crud/js/jquery_plugins/ajax-chosen.js
+++ b/assets/grocery_crud/js/jquery_plugins/ajax-chosen.js
@@ -33,7 +33,7 @@
           $.each(items, function(value, text) {
             return $("<option />").attr('value', value).html(text).appendTo(select);
           });
-          select.trigger("liszt:updated");
+          select.trigger("chosen:updated");
           field.attr('value', val);
           if (typeof success !== "undefined" && success !== null) return success();
         };

--- a/assets/grocery_crud/themes/datatables/js/datatables-add.js
+++ b/assets/grocery_crud/themes/datatables/js/datatables-add.js
@@ -138,6 +138,6 @@ $(function(){
 		});
 
 		$('.chosen-multiple-select, .chosen-select, .ajax-chosen-select').each(function(){
-			$(this).trigger("liszt:updated");
+			$(this).trigger("chosen:updated");
 		});
 	}

--- a/assets/grocery_crud/themes/flexigrid/js/flexigrid-add.js
+++ b/assets/grocery_crud/themes/flexigrid/js/flexigrid-add.js
@@ -141,6 +141,6 @@ $(function(){
 		});
 
 		$('.chosen-multiple-select, .chosen-select, .ajax-chosen-select').each(function(){
-			$(this).trigger("liszt:updated");
+			$(this).trigger("chosen:updated");
 		});
 	}


### PR DESCRIPTION
The chosen library doesn't use the name: liszt anymore: https://stackoverflow.com/a/18852516/9577970
Updated to the modern name: chosen

This fixes the following bug:
0. You have form with one or more selec form elements
1. Add an item
2. The form fields reset, but the selects seem to keep their old values (but only visually, because when trying to submit there is an error they are required)
