### PR TITLE
Fix search mixing where and set_relation

### DIFF
--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -620,9 +620,14 @@ class grocery_CRUD_Model_Driver extends grocery_CRUD_Field_Types
             } elseif ($state_info->search->field !== null) {
 				if (isset($temp_relation[$state_info->search->field])) {
 					if (is_array($temp_relation[$state_info->search->field])) {
-						foreach ($temp_relation[$state_info->search->field] as $search_field) {
-							$this->or_like($search_field , $state_info->search->text);
-                        }
+					      $temp_where_query_array = [];
+					      foreach ($temp_relation[$state_info->search->field] as $search_field) {
+						$escaped_text = $this->basic_model->escape_str($state_info->search->text);
+						$temp_where_query_array[] = $search_field . ' LIKE \'%' . $escaped_text . '%\'';
+					      }
+					      if (!empty($temp_where_query_array)) {
+						$this->where('(' . implode(' OR ', $temp_where_query_array) . ')', null);
+					      }
                     } else {
 						$this->like($temp_relation[$state_info->search->field] , $state_info->search->text);
                     }


### PR DESCRIPTION
Unexpected search results when there is a "where" defined and set_relation showing multiple fields from related table.
I replaced and created manually the "or_like" sql sentence, due to it was not taking into account if there was a predefined "where" and if it was mixed with a set_relation showing more than one field {field1} {field2}. i.e:
   $crud->set_table('invoices');
   $crud->where('invoices.status','1');
   $crud->set_relation('client_id','clients','{id_card} {name}');
Then search by choosing the clients column.
   * incorrect behavior, before: x=1 and y=2 or z=2
   * good one, now: where x=1 and (y=2 or z=2)